### PR TITLE
chore: initialize repo metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,36 @@
-# Compiled class file
-*.class
+# Kotlin/Gradle
+.gradle/
+**/build/
+!**/src/**/build/
 
-# Log file
+# Gradle wrapper
+/gradle/
+/gradlew
+/gradlew.bat
+
+# Kotlin compiler and plugin data
+.kotlinc/
+.kotlin/
+
+# IDE files
+.idea/
+*.iml
+
+# Logs
 *.log
 
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
+# Package files
 *.jar
 *.war
-*.nar
 *.ear
 *.zip
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# JVM crash logs
 hs_err_pid*
 replay_pid*
 
-# Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
-.kotlin/
+# OS files
+.DS_Store
+

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+This project is licensed under the MIT License.
+
+This product includes software developed by Softwareologists and contributors.
+


### PR DESCRIPTION
## Summary
- configure `.gitignore` for Kotlin/Gradle projects
- add missing `NOTICE` file

Closes phase1 task 1 from the implementation plan.

## Testing
- `./gradlew build` *(fails: No such file or directory)*
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685fd41f38e8832a8188b817ca6d36bb