### PR TITLE
feat: add flow schema

### DIFF
--- a/core/src/main/resources/flow.schema.yaml
+++ b/core/src/main/resources/flow.schema.yaml
@@ -1,0 +1,78 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://softwareologists.tech/qa/flow.schema.yaml"
+title: "QA Helper Flow"
+description: |
+  Defines the structure of a QA Helper flow file used to record and
+  replay application interactions.
+type: object
+required:
+  - version
+  - appVersion
+  - emulator
+  - steps
+properties:
+  version:
+    type: string
+    description: Version of the flow format.
+  appVersion:
+    type: string
+    description: Version of the application under test.
+  emulator:
+    type: object
+    description: Recorded emulator data.
+    properties:
+      http:
+        type: object
+        description: Captured HTTP interactions.
+        properties:
+          interactions:
+            type: array
+            description: Sequence of HTTP calls.
+            items:
+              type: object
+              required: [method, path]
+              properties:
+                method:
+                  type: string
+                path:
+                  type: string
+                headers:
+                  type: object
+                  additionalProperties:
+                    type: string
+                body:
+                  type: string
+                  nullable: true
+      file:
+        type: object
+        description: Captured file system events.
+        properties:
+          events:
+            type: array
+            description: Chronological file events.
+            items:
+              type: object
+              required: [type, path, timestamp]
+              properties:
+                type:
+                  type: string
+                  enum: [CREATE, MODIFY, DELETE, MOVE]
+                path:
+                  type: string
+                timestamp:
+                  type: string
+                  format: date-time
+    required:
+      - http
+      - file
+  steps:
+    type: array
+    description: Ordered steps performed during the flow.
+    items:
+      type: object
+      required: [id, description]
+      properties:
+        id:
+          type: string
+        description:
+          type: string


### PR DESCRIPTION
Closes phase2/task 5

## Summary
- define flow.schema.yaml under core module

## Testing
- `gradle build`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_b_685fdaf92d10832ab185f3c60f3154cf