### PR TITLE
feat: add ServiceLoader plugin registry

### DIFF
--- a/core/src/main/kotlin/tech/softwareologists/qa/core/PluginRegistry.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/PluginRegistry.kt
@@ -1,0 +1,23 @@
+package tech.softwareologists.qa.core
+
+import java.util.ServiceLoader
+
+/**
+ * Loads available plugin implementations using [ServiceLoader].
+ */
+object PluginRegistry {
+    /** Available [HttpEmulator] implementations. */
+    val httpEmulators: List<HttpEmulator> by lazy { load() }
+
+    /** Available [FileIoEmulator] implementations. */
+    val fileIoEmulators: List<FileIoEmulator> by lazy { load() }
+
+    /** Available [LauncherPlugin] implementations. */
+    val launcherPlugins: List<LauncherPlugin> by lazy { load() }
+
+    /** Available [DatabaseManager] implementations. */
+    val databaseManagers: List<DatabaseManager> by lazy { load() }
+
+    private inline fun <reified T> load(): List<T> =
+        ServiceLoader.load(T::class.java).toList()
+}

--- a/plugins/fileio-emulator/build.gradle.kts
+++ b/plugins/fileio-emulator/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(project(":core"))
+}

--- a/plugins/fileio-emulator/src/main/kotlin/tech/softwareologists/qa/fileio/NioFileIoEmulator.kt
+++ b/plugins/fileio-emulator/src/main/kotlin/tech/softwareologists/qa/fileio/NioFileIoEmulator.kt
@@ -1,0 +1,17 @@
+package tech.softwareologists.qa.fileio
+
+import java.nio.file.Path
+import tech.softwareologists.qa.core.FileEvent
+import tech.softwareologists.qa.core.FileIoEmulator
+
+class NioFileIoEmulator : FileIoEmulator {
+    override fun watch(paths: List<Path>) {
+        // no-op
+    }
+
+    override fun stop() {
+        // no-op
+    }
+
+    override fun events(): List<FileEvent> = emptyList()
+}

--- a/plugins/fileio-emulator/src/main/resources/META-INF/services/tech.softwareologists.qa.core.FileIoEmulator
+++ b/plugins/fileio-emulator/src/main/resources/META-INF/services/tech.softwareologists.qa.core.FileIoEmulator
@@ -1,0 +1,1 @@
+tech.softwareologists.qa.fileio.NioFileIoEmulator

--- a/plugins/http-emulator/build.gradle.kts
+++ b/plugins/http-emulator/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(project(":core"))
+}

--- a/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
+++ b/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
@@ -1,0 +1,14 @@
+package tech.softwareologists.qa.http
+
+import tech.softwareologists.qa.core.HttpEmulator
+import tech.softwareologists.qa.core.HttpInteraction
+
+class KtorHttpEmulator : HttpEmulator {
+    override fun start(): String = "http://localhost"
+
+    override fun stop() {
+        // no-op
+    }
+
+    override fun interactions(): List<HttpInteraction> = emptyList()
+}

--- a/plugins/http-emulator/src/main/resources/META-INF/services/tech.softwareologists.qa.core.HttpEmulator
+++ b/plugins/http-emulator/src/main/resources/META-INF/services/tech.softwareologists.qa.core.HttpEmulator
@@ -1,0 +1,1 @@
+tech.softwareologists.qa.http.KtorHttpEmulator


### PR DESCRIPTION
Closes phase2/task 6

## Summary
- register stub plugin implementations for SPI discovery
- configure `META-INF/services` for http and file I/O emulators
- add `PluginRegistry` in `core` for loading available plugins

## Testing
- `gradle build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_b_685fe1ad8c78832a8c08a093c6d3b20f