### PR TITLE
feat: introduce FlowExecutor skeleton

### DIFF
--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
@@ -1,0 +1,21 @@
+package tech.softwareologists.qa.core
+
+/**
+ * Executes recorded flows in either recording or playback mode.
+ */
+class FlowExecutor(
+    private val httpEmulator: HttpEmulator,
+    private val fileIoEmulator: FileIoEmulator,
+    private val launcher: LauncherPlugin,
+    private val databaseManager: DatabaseManager? = null,
+) {
+    /** Starts emulators and launches the SUT in recording mode. */
+    fun record(config: LaunchConfig) {
+        // stub
+    }
+
+    /** Starts emulators with recorded data and replays the flow. */
+    fun playback(config: LaunchConfig) {
+        // stub
+    }
+}


### PR DESCRIPTION
Closes phase2/task 7

## Summary
- add `FlowExecutor` in core
- stub out `record` and `playback` methods

## Testing
- `gradle build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_b_685fea1d9264832ab37af4786767888a