### PR TITLE
feat: implement KtorHttpEmulator

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,12 @@
 [versions]
 kotlin = "1.8.22"
+ktor = "2.3.2"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+
+[libraries]
+ktor-server-core = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktor" }
+ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty-jvm", version.ref = "ktor" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core-jvm", version.ref = "ktor" }
+ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio-jvm", version.ref = "ktor" }

--- a/plugins/http-emulator/build.gradle.kts
+++ b/plugins/http-emulator/build.gradle.kts
@@ -1,3 +1,9 @@
 dependencies {
     implementation(project(":core"))
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.ktor.client.core)
+    testImplementation(libs.ktor.client.cio)
 }

--- a/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
+++ b/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
@@ -1,14 +1,54 @@
 package tech.softwareologists.qa.http
 
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
 import tech.softwareologists.qa.core.HttpEmulator
 import tech.softwareologists.qa.core.HttpInteraction
 
-class KtorHttpEmulator : HttpEmulator {
-    override fun start(): String = "http://localhost"
+/**
+ * Simple [HttpEmulator] backed by an embedded Ktor server.
+ * When started without stubs, it records incoming HTTP calls.
+ * When provided with stubbed [HttpInteraction]s, it replays them as responses.
+ */
+class KtorHttpEmulator(private val stubs: List<HttpInteraction> = emptyList()) : HttpEmulator {
+    private val recorded = mutableListOf<HttpInteraction>()
+    private var server: ApplicationEngine? = null
+    private var baseUrl: String = ""
 
-    override fun stop() {
-        // no-op
+    override fun start(): String {
+        server = embeddedServer(Netty, port = 0) {
+            routing {
+                route("{...}") {
+                    handle {
+                        val method = call.request.httpMethod.value
+                        val path = call.request.uri
+                        val headers = call.request.headers.toMap().mapValues { it.value.joinToString() }
+                        val body = call.receiveText().ifEmpty { null }
+                        recorded += HttpInteraction(method, path, headers, body)
+
+                        val stub = stubs.firstOrNull { it.method == method && it.path == path }
+                        val responseBody = stub?.body ?: ""
+                        call.respondText(text = responseBody, status = HttpStatusCode.OK)
+                    }
+                }
+            }
+        }.start(wait = false)
+        val port = server!!.environment.connectors.first().port
+        baseUrl = "http://localhost:$port"
+        return baseUrl
     }
 
-    override fun interactions(): List<HttpInteraction> = emptyList()
+    override fun stop() {
+        server?.stop(1000, 1000)
+        server = null
+    }
+
+    override fun interactions(): List<HttpInteraction> = recorded.toList()
 }

--- a/plugins/http-emulator/src/test/kotlin/tech/softwareologists/qa/http/KtorHttpEmulatorTest.kt
+++ b/plugins/http-emulator/src/test/kotlin/tech/softwareologists/qa/http/KtorHttpEmulatorTest.kt
@@ -1,0 +1,47 @@
+package tech.softwareologists.qa.http
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.bodyAsText
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import tech.softwareologists.qa.core.HttpInteraction
+
+class KtorHttpEmulatorTest {
+    private var emulator: KtorHttpEmulator? = null
+
+    @AfterTest
+    fun tearDown() {
+        emulator?.stop()
+    }
+
+    @Test
+    fun should_record_http_interaction() = kotlinx.coroutines.runBlocking {
+        emulator = KtorHttpEmulator()
+        val baseUrl = emulator!!.start()
+        val client = HttpClient(CIO)
+
+        client.get("$baseUrl/hello")
+        emulator!!.stop()
+
+        val interactions = emulator!!.interactions()
+        assertEquals(1, interactions.size)
+        val recorded = interactions.first()
+        assertEquals("GET", recorded.method)
+        assertEquals("/hello", recorded.path)
+    }
+
+    @Test
+    fun should_replay_stubbed_response() = kotlinx.coroutines.runBlocking {
+        val stub = HttpInteraction("GET", "/hello", emptyMap(), "world")
+        emulator = KtorHttpEmulator(listOf(stub))
+        val baseUrl = emulator!!.start()
+        val client = HttpClient(CIO)
+
+        val response = client.get("$baseUrl/hello")
+        val body = response.bodyAsText()
+        assertEquals("world", body)
+    }
+}


### PR DESCRIPTION
Closes phase3/task 8

## Summary
- add Ktor dependencies
- implement `KtorHttpEmulator` with record and replay behavior
- register dependencies for tests
- add unit tests for recording and replaying a sample HTTP call

## Testing
- `gradle build` *(fails: Cannot find a Java installation matching 17)*
- `gradle test` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_b_685febdeb7b8832ab01d7ab2a3b1f34f