### PR TITLE
build: use Java 21 toolchain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Use this guide to generate code, open pull requests, and interact with the repos
 ## 6. Agent Configuration
 
 - **Environment**:
-  - JDK 17+, Gradle 7+, Kotlin 1.8.
+  - JDK 21+, Gradle 7+, Kotlin 2.2.
   - Access to GitHub repository with write permissions.
 - **Tools**:
   - OpenAI or equivalent LLM with code-generation capabilities.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ Please read our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before contributing. We
    cd qa-helper
    ```
 2. Install prerequisites:
-   - JDK 17+
+   - JDK 21+
    - Gradle 7+
-   - Kotlin 1.8 (via Gradle toolchain)
+   - Kotlin 2.2 (via Gradle toolchain)
 3. Open the project in your IDE (IntelliJ IDEA recommended) or VS Code with the provided devcontainer.
 
 ---

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -19,7 +19,7 @@ This plan breaks the QA Helper project into discrete, ordered tasks. Each task c
 2. **Configure Gradle Build**  
    - Add `settings.gradle.kts` including subprojects: `core`, `plugins/http-emulator`, `plugins/fileio-emulator`, `app`.  
    - Create root `build.gradle.kts` with version catalog and common dependencies (Kotlin, Jackson).  
-   - Define Kotlin and Java toolchain versions (Kotlin 1.8, JVM 17).
+   - Define Kotlin and Java toolchain versions (Kotlin 2.2, JVM 21).
 
 3. **Module Skeletons**  
    - Create empty Gradle modules: `core`, `plugins/http-emulator`, `plugins/fileio-emulator`, `app`.  

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 ### Prerequisites
 
-- **Java 17+**
+- **Java 21+**
 - **Gradle 7.5+** (wrapper included)
-- **Kotlin 1.8+** (via Gradle toolchain)
+- **Kotlin 2.2+** (via Gradle toolchain)
 - **Windows 10/11, macOS 11+, or Linux**
 
 ### Installation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,9 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
     extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
-        jvmToolchain(17)
+        jvmToolchain(21)
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.22"
+kotlin = "2.2.0"
 ktor = "2.3.2"
 
 [plugins]


### PR DESCRIPTION
Closes #6

## Summary
- update Kotlin version catalog to 2.2.0
- set Gradle JVM toolchain to 21 and jvmTarget to JVM_21
- document Java 21 and Kotlin 2.2 across README and contributing docs

## Testing
- `./gradlew build` *(fails: No such file or directory)*
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685fed2f88bc832aa2962986ea1a8e95