### PR TITLE
feat: implement NioFileIoEmulator

### DIFF
--- a/plugins/fileio-emulator/build.gradle.kts
+++ b/plugins/fileio-emulator/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     implementation(project(":core"))
+    testImplementation(kotlin("test"))
 }

--- a/plugins/fileio-emulator/src/main/kotlin/tech/softwareologists/qa/fileio/NioFileIoEmulator.kt
+++ b/plugins/fileio-emulator/src/main/kotlin/tech/softwareologists/qa/fileio/NioFileIoEmulator.kt
@@ -1,17 +1,69 @@
 package tech.softwareologists.qa.fileio
 
+import java.nio.file.FileSystems
 import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_DELETE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.StandardWatchEventKinds.OVERFLOW
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+import java.time.Instant
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import tech.softwareologists.qa.core.FileEvent
+import tech.softwareologists.qa.core.FileEventType
 import tech.softwareologists.qa.core.FileIoEmulator
 
+/**
+ * [FileIoEmulator] implementation backed by Java NIO's [WatchService].
+ */
 class NioFileIoEmulator : FileIoEmulator {
+    private val recorded = mutableListOf<FileEvent>()
+    private val executor = Executors.newSingleThreadExecutor()
+
+    private var watchService: WatchService? = null
+    private var future: Future<*>? = null
+
     override fun watch(paths: List<Path>) {
-        // no-op
+        watchService = FileSystems.getDefault().newWatchService()
+        val service = watchService ?: return
+
+        for (path in paths) {
+            path.register(service, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)
+        }
+
+        future = executor.submit {
+            try {
+                while (!Thread.currentThread().isInterrupted) {
+                    val key: WatchKey = service.take()
+                    val parent = key.watchable() as Path
+                    for (event in key.pollEvents()) {
+                        if (event.kind() == OVERFLOW) continue
+                        val child = parent.resolve(event.context() as Path)
+                        val type = when (event.kind()) {
+                            ENTRY_CREATE -> FileEventType.CREATE
+                            ENTRY_MODIFY -> FileEventType.MODIFY
+                            ENTRY_DELETE -> FileEventType.DELETE
+                            else -> null
+                        }
+                        if (type != null) {
+                            recorded += FileEvent(type, child, Instant.now())
+                        }
+                    }
+                    if (!key.reset()) break
+                }
+            } catch (_: InterruptedException) {
+                // allow thread exit
+            }
+        }
     }
 
     override fun stop() {
-        // no-op
+        future?.cancel(true)
+        watchService?.close()
+        executor.shutdownNow()
     }
 
-    override fun events(): List<FileEvent> = emptyList()
+    override fun events(): List<FileEvent> = recorded.toList()
 }

--- a/plugins/fileio-emulator/src/test/kotlin/tech/softwareologists/qa/fileio/NioFileIoEmulatorTest.kt
+++ b/plugins/fileio-emulator/src/test/kotlin/tech/softwareologists/qa/fileio/NioFileIoEmulatorTest.kt
@@ -1,0 +1,45 @@
+package tech.softwareologists.qa.fileio
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import tech.softwareologists.qa.core.FileEventType
+
+class NioFileIoEmulatorTest {
+    private lateinit var emulator: NioFileIoEmulator
+    private lateinit var tempDir: Path
+
+    @BeforeTest
+    fun setUp() {
+        tempDir = createTempDirectory()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        emulator.stop()
+        tempDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun should_capture_create_modify_delete_events() {
+        emulator = NioFileIoEmulator()
+        emulator.watch(listOf(tempDir))
+
+        val file = tempDir.resolve("sample.txt")
+        Files.writeString(file, "hello")
+        Files.writeString(file, " world", java.nio.file.StandardOpenOption.APPEND)
+        Files.delete(file)
+
+        Thread.sleep(500)
+        emulator.stop()
+
+        val types = emulator.events().map { it.type }
+        assertTrue(FileEventType.CREATE in types)
+        assertTrue(FileEventType.MODIFY in types)
+        assertTrue(FileEventType.DELETE in types)
+    }
+}

--- a/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
+++ b/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
@@ -5,7 +5,9 @@ import io.ktor.server.application.call
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import io.ktor.server.request.httpMethod
 import io.ktor.server.request.receiveText
+import io.ktor.server.request.uri
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
@@ -29,7 +31,7 @@ class KtorHttpEmulator(private val stubs: List<HttpInteraction> = emptyList()) :
                     handle {
                         val method = call.request.httpMethod.value
                         val path = call.request.uri
-                        val headers = call.request.headers.toMap().mapValues { it.value.joinToString() }
+                        val headers = call.request.headers.entries().associate { it.key to it.value.joinToString() }
                         val body = call.receiveText().ifEmpty { null }
                         recorded += HttpInteraction(method, path, headers, body)
 


### PR DESCRIPTION
Closes #9

## Summary
- implement `NioFileIoEmulator` using Java NIO `WatchService`
- register test dependencies for file I/O emulator plugin
- add unit test verifying create/modify/delete events
- fix missing imports in `KtorHttpEmulator`

## Testing
- `gradle test` *(fails: compile errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685fee434054832abd56e57985b5cb6b