### PR TITLE
fix: update http emulator port handling

### DIFF
--- a/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
+++ b/plugins/http-emulator/src/main/kotlin/tech/softwareologists/qa/http/KtorHttpEmulator.kt
@@ -42,7 +42,7 @@ class KtorHttpEmulator(private val stubs: List<HttpInteraction> = emptyList()) :
                 }
             }
         }.start(wait = false)
-        val port = server!!.environment.connectors.first().port
+        val port = kotlinx.coroutines.runBlocking { server!!.resolvedConnectors().first().port }
         baseUrl = "http://localhost:$port"
         return baseUrl
     }

--- a/plugins/http-emulator/src/test/kotlin/tech/softwareologists/qa/http/KtorHttpEmulatorTest.kt
+++ b/plugins/http-emulator/src/test/kotlin/tech/softwareologists/qa/http/KtorHttpEmulatorTest.kt
@@ -1,7 +1,7 @@
 package tech.softwareologists.qa.http
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.bodyAsText
+import io.ktor.client.statement.bodyAsText
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
 import kotlin.test.AfterTest


### PR DESCRIPTION
## Summary
- fix import in HTTP emulator tests
- ensure KtorHttpEmulator reads actual assigned port

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_b_686086f4b504832a8dd227d6cea78c04