### PR TITLE
feat: add basic CLI skeleton

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    application
+}
+
+dependencies {
+    implementation(project(":core"))
+    implementation(libs.clikt)
+
+    testImplementation(kotlin("test"))
+}
+
+application {
+    mainClass.set("tech.softwareologists.qa.app.MainKt")
+}

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
@@ -1,0 +1,43 @@
+package tech.softwareologists.qa.app
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+class RecordCommand : CliktCommand(help = "Record application interactions") {
+    override fun run() {
+        echo("Recording flow (TODO)")
+    }
+}
+
+class ReplayCommand : CliktCommand(help = "Replay a recorded flow") {
+    override fun run() {
+        echo("Replaying flow (TODO)")
+    }
+}
+
+class BranchCommand : CliktCommand(help = "Manage branches") {
+    override fun run() {
+        echo("Branching (TODO)")
+    }
+}
+
+class RunCommand : CliktCommand(help = "Run a flow end-to-end") {
+    override fun run() {
+        echo("Running flow (TODO)")
+    }
+}
+
+class QaCli : CliktCommand(name = "qa-helper") {
+    init {
+        subcommands(
+            RecordCommand(),
+            ReplayCommand(),
+            BranchCommand(),
+            RunCommand()
+        )
+    }
+
+    override fun run() = Unit
+}
+
+fun main(args: Array<String>) = QaCli().main(args)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.2.0"
 ktor = "2.3.2"
 h2 = "2.2.224"
 mssql = "12.10.0.jre11"
+clikt = "4.2.2"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -14,3 +15,4 @@ ktor-client-core = { group = "io.ktor", name = "ktor-client-core-jvm", version.r
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio-jvm", version.ref = "ktor" }
 h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 mssql = { group = "com.microsoft.sqlserver", name = "mssql-jdbc", version.ref = "mssql" }
+clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }


### PR DESCRIPTION
Closes phase4/task 11

## Summary
- integrate Clikt as CLI framework
- create `qa-helper` root command
- add `record`, `replay`, `branch`, and `run` subcommands with placeholder logic

## Testing
- `gradle build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_b_68608f289698832aa26a0bb542a8e7ab