### PR TITLE
feat: add compose skeleton UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     application
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.compose)
 }
 
@@ -7,10 +8,11 @@ dependencies {
     implementation(project(":core"))
     implementation(libs.clikt)
     implementation(compose.desktop.currentOs)
+    implementation(compose.material3)
 
     testImplementation(kotlin("test"))
 }
 
 application {
-    mainClass.set("tech.softwareologists.qa.app.MainKt")
+    mainClass.set("tech.softwareologists.qa.app.ComposeMainKt")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,12 @@
 plugins {
     application
+    alias(libs.plugins.compose)
 }
 
 dependencies {
     implementation(project(":core"))
     implementation(libs.clikt)
+    implementation(compose.desktop.currentOs)
 
     testImplementation(kotlin("test"))
 }

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
@@ -1,0 +1,72 @@
+package tech.softwareologists.qa.app
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import javax.swing.JFileChooser
+
+@Composable
+fun MainScreen() {
+    var jarPath by remember { mutableStateOf("") }
+    var isRecording by remember { mutableStateOf(false) }
+
+    fun chooseFile() {
+        val chooser = JFileChooser()
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+            jarPath = chooser.selectedFile.absolutePath
+        }
+    }
+
+    fun startRecording() {
+        RecordCommand().main(emptyArray())
+        isRecording = true
+    }
+
+    fun stopRecording() {
+        // Placeholder for stop logic
+        isRecording = false
+    }
+
+    MaterialTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextField(
+                    value = jarPath,
+                    onValueChange = { jarPath = it },
+                    label = { Text("Application JAR/DLL") },
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { chooseFile() }) { Text("Browse") }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Text("Configuration panels go here", modifier = Modifier.weight(1f))
+
+            Row {
+                Button(onClick = { startRecording() }, enabled = !isRecording) {
+                    Text("Start Recording")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { stopRecording() }, enabled = isRecording) {
+                    Text("Stop")
+                }
+            }
+        }
+    }
+}
+
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication, title = "QA Helper") {
+        MainScreen()
+    }
+}
+

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
@@ -1,43 +1,61 @@
 package tech.softwareologists.qa.app
 
-import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.subcommands
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import javax.swing.JFileChooser
 
-class RecordCommand : CliktCommand(help = "Record application interactions") {
-    override fun run() {
-        echo("Recording flow (TODO)")
+@Composable
+fun MainScreen() {
+    var jarPath by remember { mutableStateOf("") }
+    var isRecording by remember { mutableStateOf(false) }
+
+    fun chooseFile() {
+        val chooser = JFileChooser()
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+            jarPath = chooser.selectedFile.absolutePath
+        }
+    }
+
+    MaterialTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextField(
+                    value = jarPath,
+                    onValueChange = { jarPath = it },
+                    label = { Text("Application JAR/DLL") },
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { chooseFile() }) { Text("Browse") }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Text("Configuration panels go here", modifier = Modifier.weight(1f))
+
+            Row {
+                Button(onClick = { isRecording = true /* TODO invoke CLI */ }, enabled = !isRecording) {
+                    Text("Start Recording")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { isRecording = false /* TODO invoke CLI */ }, enabled = isRecording) {
+                    Text("Stop")
+                }
+            }
+        }
     }
 }
 
-class ReplayCommand : CliktCommand(help = "Replay a recorded flow") {
-    override fun run() {
-        echo("Replaying flow (TODO)")
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication, title = "QA Helper") {
+        MainScreen()
     }
 }
-
-class BranchCommand : CliktCommand(help = "Manage branches") {
-    override fun run() {
-        echo("Branching (TODO)")
-    }
-}
-
-class RunCommand : CliktCommand(help = "Run a flow end-to-end") {
-    override fun run() {
-        echo("Running flow (TODO)")
-    }
-}
-
-class QaCli : CliktCommand(name = "qa-helper") {
-    init {
-        subcommands(
-            RecordCommand(),
-            ReplayCommand(),
-            BranchCommand(),
-            RunCommand()
-        )
-    }
-
-    override fun run() = Unit
-}
-
-fun main(args: Array<String>) = QaCli().main(args)

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
@@ -1,61 +1,43 @@
 package tech.softwareologists.qa.app
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.application
-import javax.swing.JFileChooser
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
 
-@Composable
-fun MainScreen() {
-    var jarPath by remember { mutableStateOf("") }
-    var isRecording by remember { mutableStateOf(false) }
-
-    fun chooseFile() {
-        val chooser = JFileChooser()
-        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
-            jarPath = chooser.selectedFile.absolutePath
-        }
-    }
-
-    MaterialTheme {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                TextField(
-                    value = jarPath,
-                    onValueChange = { jarPath = it },
-                    label = { Text("Application JAR/DLL") },
-                    modifier = Modifier.weight(1f)
-                )
-                Spacer(Modifier.width(8.dp))
-                Button(onClick = { chooseFile() }) { Text("Browse") }
-            }
-
-            Spacer(Modifier.height(16.dp))
-            Text("Configuration panels go here", modifier = Modifier.weight(1f))
-
-            Row {
-                Button(onClick = { isRecording = true /* TODO invoke CLI */ }, enabled = !isRecording) {
-                    Text("Start Recording")
-                }
-                Spacer(Modifier.width(8.dp))
-                Button(onClick = { isRecording = false /* TODO invoke CLI */ }, enabled = isRecording) {
-                    Text("Stop")
-                }
-            }
-        }
+class RecordCommand : CliktCommand(help = "Record application interactions") {
+    override fun run() {
+        echo("Recording flow (TODO)")
     }
 }
 
-fun main() = application {
-    Window(onCloseRequest = ::exitApplication, title = "QA Helper") {
-        MainScreen()
+class ReplayCommand : CliktCommand(help = "Replay a recorded flow") {
+    override fun run() {
+        echo("Replaying flow (TODO)")
     }
 }
+
+class BranchCommand : CliktCommand(help = "Manage branches") {
+    override fun run() {
+        echo("Branching (TODO)")
+    }
+}
+
+class RunCommand : CliktCommand(help = "Run a flow end-to-end") {
+    override fun run() {
+        echo("Running flow (TODO)")
+    }
+}
+
+class QaCli : CliktCommand(name = "qa-helper") {
+    init {
+        subcommands(
+            RecordCommand(),
+            ReplayCommand(),
+            BranchCommand(),
+            RunCommand()
+        )
+    }
+
+    override fun run() = Unit
+}
+
+fun main(args: Array<String>) = QaCli().main(args)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
+        google()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,13 +6,15 @@ mssql = "12.10.0.jre11"
 clikt = "4.2.2"
 ktlint-gradle = "11.6.0"
 detekt = "1.23.1"
-compose = "1.5.11"
+compose = "1.8.2"
+kotlin-compose = "2.2.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin-compose" }
 
 [libraries]
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,11 +6,13 @@ mssql = "12.10.0.jre11"
 clikt = "4.2.2"
 ktlint-gradle = "11.6.0"
 detekt = "1.23.1"
+compose = "1.5.11"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 
 [libraries]
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,12 +4,16 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        google()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        google()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 


### PR DESCRIPTION
Closes phase4/task 12

## Summary
- enable Compose Multiplatform plugin
- add Compose dependencies for the app
- implement a simple window with file chooser and start/stop buttons

## Testing
- `gradle build` *(fails: Could not initialize class org.jetbrains.compose.experimental.internal.ConfigureNativeCompilerCachingKt)*
- `gradle test` *(fails: Could not initialize class org.jetbrains.compose.experimental.internal.ConfigureNativeCompilerCachingKt)*
- `gradle ktlintCheck` *(fails: Could not initialize class org.jetbrains.compose.experimental.internal.ConfigureNativeCompilerCachingKt)*

------
https://chatgpt.com/codex/tasks/task_b_6861c4fef668832a8508cd76144560e7