### PR TITLE
test: add compose ui test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(compose.material3)
 
     testImplementation(kotlin("test"))
+    testImplementation(libs.compose.ui.test.junit4)
 }
 
 application {

--- a/app/src/test/kotlin/tech/softwareologists/qa/app/MainScreenTest.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/MainScreenTest.kt
@@ -1,0 +1,33 @@
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.*
+import org.junit.Rule
+import org.junit.Test
+
+class MainScreenTest {
+    @get:Rule
+    val composeTestRule: ComposeContentTestRule = createComposeRule()
+
+    @Test
+    fun start_and_stop_button_toggle_state() {
+        composeTestRule.setContent {
+            tech.softwareologists.qa.app.MainScreen()
+        }
+
+        val startButton = composeTestRule.onNodeWithText("Start Recording")
+        val stopButton = composeTestRule.onNodeWithText("Stop")
+
+        startButton.assertIsEnabled()
+        stopButton.assertIsNotEnabled()
+
+        startButton.performClick()
+
+        startButton.assertIsNotEnabled()
+        stopButton.assertIsEnabled()
+
+        stopButton.performClick()
+
+        startButton.assertIsEnabled()
+        stopButton.assertIsNotEnabled()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,3 +24,4 @@ ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio-jvm", version.ref
 h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 mssql = { group = "com.microsoft.sqlserver", name = "mssql-jdbc", version.ref = "mssql" }
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
+compose-ui-test-junit4 = { group = "org.jetbrains.compose.ui", name = "ui-test-junit4-desktop", version.ref = "compose" }


### PR DESCRIPTION
Closes #12

Adds a unit test for the Compose UI skeleton.
- adds `ui-test-junit4` dependency to the app module
- includes version catalog entry for the dependency
- verifies start/stop buttons toggle state in `MainScreen`

### Testing
- `gradle lint`
- `gradle test`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_b_6861cba7d03c832aaeb0dbd5c5f91746