### PR TITLE
feat: launch plugins on start recording

### DIFF
--- a/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
@@ -26,7 +26,7 @@ fun MainScreen() {
     }
 
     fun startRecording() {
-        RecordCommand().main(emptyArray())
+        RecordCommand().main(arrayOf(jarPath))
         isRecording = true
     }
 

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
@@ -2,10 +2,29 @@ package tech.softwareologists.qa.app
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.types.path
+import tech.softwareologists.qa.core.LaunchConfig
+import tech.softwareologists.qa.core.PluginRegistry
 
 class RecordCommand : CliktCommand(help = "Record application interactions") {
+    private val executable by argument(help = "Path to application JAR/DLL").path()
+
     override fun run() {
-        echo("Recording flow (TODO)")
+        val http = PluginRegistry.httpEmulators.firstOrNull()
+        val fileIo = PluginRegistry.fileIoEmulators.firstOrNull()
+        val launcher = PluginRegistry.launcherPlugins.firstOrNull()
+
+        if (http == null || fileIo == null || launcher == null) {
+            echo("Required plugins not available. Cannot start recording.")
+            return
+        }
+
+        http.start()
+        fileIo.watch(listOf(executable.parent))
+        launcher.launch(LaunchConfig(executable))
+
+        echo("Recording started for ${executable.fileName}")
     }
 }
 


### PR DESCRIPTION
Closes phase4/task 13

## Summary
- start the default HttpEmulator, FileIoEmulator and LauncherPlugin via `PluginRegistry` from `RecordCommand`
- pass the selected executable path from the Compose UI to the command

## Testing
- `gradle build`
- `gradle test`
- `gradle lint`


------
https://chatgpt.com/codex/tasks/task_b_6861cef775a0832a980272b4a321258b