### PR TITLE
feat: add Flow YAML serialization

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.datatype.jsr310)
+    testImplementation(kotlin("test"))
+}
+

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/Flow.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/Flow.kt
@@ -1,0 +1,33 @@
+package tech.softwareologists.qa.core
+
+/**
+ * High-level representation of a recorded QA flow.
+ */
+data class Flow(
+    val version: String,
+    val appVersion: String,
+    val emulator: EmulatorData,
+    val steps: List<FlowStep>
+)
+
+/** Container for recorded emulator data. */
+data class EmulatorData(
+    val http: HttpData,
+    val file: FileData
+)
+
+/** Recorded HTTP interactions. */
+data class HttpData(
+    val interactions: List<HttpInteraction> = emptyList()
+)
+
+/** Recorded file system events. */
+data class FileData(
+    val events: List<FileEvent> = emptyList()
+)
+
+/** User-defined step within a flow. */
+data class FlowStep(
+    val id: String,
+    val description: String
+)

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
@@ -10,8 +10,26 @@ class FlowExecutor(
     private val databaseManager: DatabaseManager? = null,
 ) {
     /** Starts emulators and launches the SUT in recording mode. */
-    fun record(config: LaunchConfig) {
-        // stub
+    fun record(config: LaunchConfig, output: java.nio.file.Path) {
+        httpEmulator.start()
+        fileIoEmulator.watch(listOf(config.workingDir ?: config.executable.parent))
+
+        val process = launcher.launch(config)
+        process.waitFor()
+
+        fileIoEmulator.stop()
+        httpEmulator.stop()
+
+        val flow = Flow(
+            version = "1",
+            appVersion = "unknown",
+            emulator = EmulatorData(
+                http = HttpData(httpEmulator.interactions()),
+                file = FileData(fileIoEmulator.events())
+            ),
+            steps = emptyList()
+        )
+        FlowIO.write(flow, output)
     }
 
     /** Starts emulators with recorded data and replays the flow. */

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowIO.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowIO.kt
@@ -1,0 +1,26 @@
+package tech.softwareologists.qa.core
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Utility for reading and writing [Flow] objects as YAML. */
+object FlowIO {
+    private val mapper: ObjectMapper =
+        ObjectMapper(YAMLFactory())
+            .registerKotlinModule()
+            .findAndRegisterModules()
+
+    fun write(flow: Flow, path: Path) {
+        Files.newBufferedWriter(path).use { writer ->
+            mapper.writeValue(writer, flow)
+        }
+    }
+
+    fun read(path: Path): Flow =
+        Files.newBufferedReader(path).use { reader ->
+            mapper.readValue(reader, Flow::class.java)
+        }
+}

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/FlowIOTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/FlowIOTest.kt
@@ -1,0 +1,35 @@
+package tech.softwareologists.qa.core
+
+import java.nio.file.Files
+import java.time.Instant
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FlowIOTest {
+    @Test
+    fun round_trip_serialization() {
+        val tempDir = createTempDirectory()
+        val file = tempDir.resolve("flow.yaml")
+
+        val interaction = HttpInteraction("GET", "/hello")
+        val event = FileEvent(FileEventType.CREATE, tempDir.resolve("a.txt"), Instant.EPOCH)
+        val flow = Flow(
+            version = "1",
+            appVersion = "test",
+            emulator = EmulatorData(
+                http = HttpData(listOf(interaction)),
+                file = FileData(listOf(event))
+            ),
+            steps = listOf(FlowStep("1", "step"))
+        )
+
+        FlowIO.write(flow, file)
+        val loaded = FlowIO.read(file)
+
+        assertEquals(flow, loaded)
+
+        Files.deleteIfExists(file)
+        Files.deleteIfExists(tempDir)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ktlint-gradle = "11.6.0"
 detekt = "1.23.1"
 compose = "1.8.2"
 kotlin-compose = "2.2.0"
+jackson = "2.17.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -25,3 +26,6 @@ h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 mssql = { group = "com.microsoft.sqlserver", name = "mssql-jdbc", version.ref = "mssql" }
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
 compose-ui-test-junit4 = { group = "org.jetbrains.compose.ui", name = "ui-test-junit4-desktop", version.ref = "compose" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
+jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson" }
+jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }


### PR DESCRIPTION
## Summary
- add Jackson YAML dependencies
- implement Flow data model with YAML read/write utility
- update FlowExecutor to persist flows when recording
- test Flow round-trip serialization

## Testing
- `gradle clean build`
- `gradle lint`


------
https://chatgpt.com/codex/tasks/task_b_6861d19125e4832ab139a34c3e0ee022