### PR TITLE
feat: add playback utilities

### DIFF
--- a/core/src/main/kotlin/tech/softwareologists/qa/core/PlaybackUtils.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/PlaybackUtils.kt
@@ -1,0 +1,35 @@
+package tech.softwareologists.qa.core
+
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+
+/** Utility functions for flow playback. */
+
+/**
+ * Convert recorded [HttpInteraction]s into a stub mapping keyed by HTTP method
+ * and path.
+ */
+fun List<HttpInteraction>.toStubMappings(): Map<Pair<String, String>, HttpInteraction> =
+    associateBy { it.method to it.path }
+
+/**
+ * Simulate the given [FileEvent]s by creating or deleting files.
+ */
+fun simulateFileEvents(events: List<FileEvent>) {
+    events.forEach { event ->
+        when (event.type) {
+            FileEventType.CREATE -> {
+                Files.createDirectories(event.path.parent)
+                Files.createFile(event.path)
+            }
+
+            FileEventType.DELETE -> Files.deleteIfExists(event.path)
+
+            FileEventType.MODIFY -> if (Files.exists(event.path)) {
+                Files.writeString(event.path, "", StandardOpenOption.APPEND)
+            }
+
+            FileEventType.MOVE -> Unit
+        }
+    }
+}

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/PlaybackUtilsTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/PlaybackUtilsTest.kt
@@ -1,0 +1,41 @@
+package tech.softwareologists.qa.core
+
+import java.nio.file.Files
+import java.time.Instant
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackUtilsTest {
+    @Test
+    fun toStubMappings_maps_by_method_and_path() {
+        val interactions = listOf(
+            HttpInteraction("GET", "/a", emptyMap(), "1"),
+            HttpInteraction("POST", "/b", emptyMap(), "2")
+        )
+
+        val map = interactions.toStubMappings()
+
+        assertEquals(interactions[0], map["GET" to "/a"])
+        assertEquals(interactions[1], map["POST" to "/b"])
+    }
+
+    @Test
+    fun simulateFileEvents_creates_and_deletes_files() {
+        val dir = createTempDirectory()
+        val target = dir.resolve("sample.txt")
+        val events = listOf(
+            FileEvent(FileEventType.CREATE, target, Instant.now()),
+            FileEvent(FileEventType.DELETE, target, Instant.now())
+        )
+
+        simulateFileEvents(events)
+
+        assertFalse(Files.exists(target))
+        assertTrue(Files.exists(dir))
+
+        dir.toFile().deleteRecursively()
+    }
+}


### PR DESCRIPTION
Closes phase5/task 15

## Summary
- convert recorded HttpInteractions into stub mappings
- add helper to simulate file events during playback
- test stub conversion and file event simulation

## Testing
- `gradle build`
- `gradle lint`
- `gradle :core:test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_b_6861d47b6480832ab5e0a643d182fee4