### PR TITLE
feat: add simple reporting exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Replay a flow:
 ./gradlew run --args="replay --flow examples/sample-flow.yaml --reportDir reports/"
 ```
 
+The report directory will contain `junit.xml` and `summary.html` alongside JSON
+evidence files.
+
 Create a branch from an existing flow:
 
 ```bash

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
@@ -71,7 +71,12 @@ class FlowExecutor(
      * Writes HTTP interactions, file events, and an optional database dump to
      * `reports/{flow}/{timestamp}` under [reportRoot].
      */
-    fun collectEvidence(flowName: String, reportRoot: java.nio.file.Path) {
+    fun collectEvidence(
+        flowName: String,
+        reportRoot: java.nio.file.Path,
+        success: Boolean,
+        details: List<String> = emptyList(),
+    ) {
         val timestamp = java.time.format.DateTimeFormatter.ISO_INSTANT
             .format(java.time.Instant.now())
         val targetDir = reportRoot.resolve(flowName).resolve(timestamp)
@@ -91,5 +96,7 @@ class FlowExecutor(
         }
 
         databaseManager?.exportDump(targetDir.resolve("db_dump.sql"))
+
+        ReportExporter.writeReports(targetDir, flowName, success, details)
     }
 }

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/ReportExporter.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/ReportExporter.kt
@@ -1,0 +1,69 @@
+package tech.softwareologists.qa.core
+
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+/** Utility for exporting run results in JUnit-XML and HTML formats. */
+object ReportExporter {
+    fun writeReports(dir: Path, flowName: String, success: Boolean, details: List<String> = emptyList()) {
+        writeJUnitXml(dir.resolve("junit.xml"), flowName, success, details)
+        writeHtml(dir.resolve("summary.html"), flowName, success, details)
+    }
+
+    private fun writeJUnitXml(target: Path, flowName: String, success: Boolean, details: List<String>) {
+        val docFactory = DocumentBuilderFactory.newInstance()
+        val docBuilder = docFactory.newDocumentBuilder()
+        val doc = docBuilder.newDocument()
+
+        val suite = doc.createElement("testsuite")
+        suite.setAttribute("name", flowName)
+        suite.setAttribute("tests", "1")
+        suite.setAttribute("failures", if (success) "0" else "1")
+        doc.appendChild(suite)
+
+        val case = doc.createElement("testcase")
+        case.setAttribute("classname", flowName)
+        case.setAttribute("name", "playback")
+        suite.appendChild(case)
+
+        if (!success) {
+            val failure = doc.createElement("failure")
+            failure.setAttribute("message", details.joinToString(";"))
+            failure.textContent = details.joinToString("\n")
+            case.appendChild(failure)
+        }
+
+        val transformer = TransformerFactory.newInstance().newTransformer()
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes")
+        Files.newOutputStream(target).use { out ->
+            transformer.transform(DOMSource(doc), StreamResult(out))
+        }
+    }
+
+    private fun writeHtml(target: Path, flowName: String, success: Boolean, details: List<String>) {
+        val status = if (success) "Passed" else "Failed"
+        val body = buildString {
+            append("<html><head><title>")
+            append("Flow Report")
+            append("</title></head><body>")
+            append("<h1>")
+            append(flowName)
+            append("</h1>")
+            append("<p>Status: <strong>")
+            append(status)
+            append("</strong></p>")
+            if (!success) {
+                append("<pre>")
+                append(details.joinToString("\n"))
+                append("</pre>")
+            }
+            append("</body></html>")
+        }
+        Files.writeString(target, body)
+    }
+}

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/EvidenceCollectionTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/EvidenceCollectionTest.kt
@@ -59,11 +59,13 @@ class EvidenceCollectionTest {
         )
         val dir = createTempDirectory()
         executor.playback(flow, LaunchConfig(java.nio.file.Paths.get("/usr/bin/true"), workingDir = dir))
-        executor.collectEvidence("sample", dir)
+        executor.collectEvidence("sample", dir, success = true)
         val tsDir = Files.list(dir.resolve("sample")).findFirst().get()
         assertTrue(Files.exists(tsDir.resolve("http_interactions.json")))
         assertTrue(Files.exists(tsDir.resolve("file_events.json")))
         assertTrue(Files.exists(tsDir.resolve("db_dump.sql")))
+        assertTrue(Files.exists(tsDir.resolve("junit.xml")))
+        assertTrue(Files.exists(tsDir.resolve("summary.html")))
         dir.toFile().deleteRecursively()
     }
 }

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/EvidenceCollectionTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/EvidenceCollectionTest.kt
@@ -58,14 +58,27 @@ class EvidenceCollectionTest {
             steps = emptyList()
         )
         val dir = createTempDirectory()
-        executor.playback(flow, LaunchConfig(java.nio.file.Paths.get("/usr/bin/true"), workingDir = dir))
+        executor.playback(
+            flow,
+            LaunchConfig(java.nio.file.Paths.get("/usr/bin/true"), workingDir = dir)
+        )
         executor.collectEvidence("sample", dir, success = true)
         val tsDir = Files.list(dir.resolve("sample")).findFirst().get()
         assertTrue(Files.exists(tsDir.resolve("http_interactions.json")))
         assertTrue(Files.exists(tsDir.resolve("file_events.json")))
         assertTrue(Files.exists(tsDir.resolve("db_dump.sql")))
-        assertTrue(Files.exists(tsDir.resolve("junit.xml")))
-        assertTrue(Files.exists(tsDir.resolve("summary.html")))
+        val junit = tsDir.resolve("junit.xml")
+        assertTrue(Files.exists(junit))
+        val suite = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(junit.toFile())
+            .documentElement
+        assertTrue(suite.nodeName == "testsuite")
+
+        val html = tsDir.resolve("summary.html")
+        assertTrue(Files.exists(html))
+        val content = Files.readString(html)
+        assertTrue("Status: <strong>Passed</strong>" in content)
         dir.toFile().deleteRecursively()
     }
 }


### PR DESCRIPTION
Closes phase6/task 19

## Summary
- generate junit.xml and summary.html for playback evidence
- update README usage docs
- add tests for report outputs

## Testing
- `gradle lint`
- `gradle test` *(fails: environment timeout)*

------
https://chatgpt.com/codex/tasks/task_b_686209e0692c832ab1c70682626cb496