### PR TITLE
docs: add sample workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ List available commands:
 
 Sample workflows and reports are available under the `examples/` directory:
 
-- `examples/sample-http-file-workflow.yaml` — demonstrates mixed HTTP and file events.
+- `examples/sample-workflow.yaml` — demonstrates mixed HTTP and file events.
 - `examples/reports/` — contains example HTML and JUnit reports.
 
 ## Documentation

--- a/examples/sample-workflow.yaml
+++ b/examples/sample-workflow.yaml
@@ -1,0 +1,30 @@
+version: "1"
+appVersion: "1.0.0"
+emulator:
+  http:
+    interactions:
+      - method: GET
+        path: /hello
+        headers:
+          Accept: application/json
+        body: ""
+      - method: POST
+        path: /upload
+        headers:
+          Content-Type: application/json
+        body: '{"data":"sample"}'
+  file:
+    events:
+      - type: CREATE
+        path: /tmp/output.txt
+        timestamp: "2024-01-01T12:00:00Z"
+      - type: MODIFY
+        path: /tmp/output.txt
+        timestamp: "2024-01-01T12:05:00Z"
+steps:
+  - id: "1"
+    description: Start application
+  - id: "2"
+    description: Issue API requests
+  - id: "3"
+    description: Write output file


### PR DESCRIPTION
Closes #21

## Summary
- add `examples/sample-workflow.yaml` showing HTTP and file events
- reference the new example in the README

## Testing
- `gradle build`
- `gradle test`
- `gradle ktlintCheck`

------
https://chatgpt.com/codex/tasks/task_b_68622d2ad2d0832abdd7a2fef98f5eea