### PR TITLE
docs: add usage and contribution guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,53 +23,14 @@
 - **Kotlin 2.2+** (via Gradle toolchain)
 - **Windows 10/11, macOS 11+, or Linux**
 
-### Installation
+See [docs/INSTALLATION.md](docs/INSTALLATION.md) for detailed installation instructions.
 
-```bash
-git clone git@github.com:your-org/qa-automation-accelerator.git
-cd qa-automation-accelerator
-./gradlew clean assemble
-```
+### GUI Launcher
+See [docs/UI_WALKTHROUGH.md](docs/UI_WALKTHROUGH.md) for a walkthrough of the desktop UI.
 
-### Running the GUI Launcher
+### CLI Quickstart
 
-1. Build the application:
-   ```bash
-   ./gradlew :app:installDist
-   ```
-2. Launch:
-   - **macOS/Linux**: `app/build/install/app/bin/app`
-   - **Windows**: `app\build\install\app\bin\app.bat`
-
-### Using the CLI
-
-Record a new flow:
-
-```bash
-./gradlew run --args="record --output examples/sample-flow.yaml"
-```
-
-Replay a flow:
-
-```bash
-./gradlew run --args="replay --flow examples/sample-flow.yaml --reportDir reports/"
-```
-
-The report directory will contain `junit.xml` and `summary.html` alongside JSON
-evidence files.
-
-Create a branch from an existing flow:
-
-```bash
-./gradlew run --args="branch create --base examples/sample-flow.yaml --at 1 --name variant"
-```
-
-List available commands:
-
-```bash
-./gradlew run --args="--help"
-```
-
+See [docs/CLI_USAGE.md](docs/CLI_USAGE.md) for detailed command examples.
 ## Examples
 
 Sample workflows and reports are available under the `examples/` directory:
@@ -88,8 +49,7 @@ Sample workflows and reports are available under the `examples/` directory:
 - **ADR Templates:** `ADRs/decisions/`
 
 ## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting issues, branching, and submitting pull requests.
+See [docs/CONTRIBUTING_OVERVIEW.md](docs/CONTRIBUTING_OVERVIEW.md) for an overview of the contribution process.
 
 ## License
 

--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -1,0 +1,35 @@
+# CLI Usage
+
+The command line interface is built with [Clikt](https://github.com/ajalt/clikt) and provides access to all core features.
+
+## Listing Commands
+
+```bash
+./gradlew run --args="--help"
+```
+
+## Recording a Flow
+
+Capture HTTP and file interactions while running your application:
+
+```bash
+./gradlew run --args="record path/to/app.jar"
+```
+
+## Replaying a Flow
+
+Execute a previously recorded flow and output a report directory:
+
+```bash
+./gradlew run --args="replay --flow examples/sample-flow.yaml --reportDir reports/"
+```
+
+## Branching
+
+Create a branch starting at a specific step in a flow:
+
+```bash
+./gradlew run --args="branch create --base examples/sample-flow.yaml --at 1 --name variant"
+```
+
+The resulting YAML file can then be replayed or further modified.

--- a/docs/CONTRIBUTING_OVERVIEW.md
+++ b/docs/CONTRIBUTING_OVERVIEW.md
@@ -1,0 +1,14 @@
+# Contribution Guidelines
+
+Thank you for your interest in improving **QA Automation Accelerator**!
+
+The full guidelines are available in the root [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Below is a short overview:
+
+- Follow our [Code of Conduct](../CODE_OF_CONDUCT.md).
+- Create a branch for each task using the `phaseX/task` naming scheme.
+- Use Conventional Commits for commit messages.
+- Run `./gradlew clean test` before opening a pull request.
+- Provide a clear description and reference the related issue in every PR.
+
+For detailed instructions on reporting bugs, requesting features, and the release process, see the main contributing document.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,42 @@
+# Installation Guide
+
+This guide explains how to install **QA Automation Accelerator** on your system.
+
+## Prerequisites
+
+- **JDK 21+**
+- **Gradle 7.5+** (wrapper included)
+- **Kotlin 2.2+** (handled by Gradle)
+- **Windows 10/11**, **macOS 11+**, or **Linux**
+
+## Cloning the Repository
+
+```bash
+git clone git@github.com:your-org/qa-automation-accelerator.git
+cd qa-automation-accelerator
+```
+
+## Building the Project
+
+Use the Gradle wrapper to compile the entire project:
+
+```bash
+./gradlew clean assemble
+```
+
+This command fetches dependencies and creates artifacts under `build/`.
+
+## Running the Application
+
+To run the desktop UI and CLI, install the distribution:
+
+```bash
+./gradlew :app:installDist
+```
+
+The launch scripts are placed under `app/build/install/app/bin/`.
+
+- **macOS/Linux**: `app/build/install/app/bin/app`
+- **Windows**: `app\build\install\app\bin\app.bat`
+
+You are now ready to launch the UI or run commands via the CLI.

--- a/docs/UI_WALKTHROUGH.md
+++ b/docs/UI_WALKTHROUGH.md
@@ -1,0 +1,32 @@
+# UI Walkthrough
+
+The desktop interface is built with **Kotlin Compose** and allows recording and managing flows without using the command line.
+
+## Launching the UI
+
+After running the installation steps from [Installation Guide](INSTALLATION.md), start the UI with:
+
+```bash
+app/build/install/app/bin/app
+```
+
+On Windows use `app\build\install\app\bin\app.bat`.
+
+## Main Screen
+
+The main window offers two panels:
+
+1. **Application JAR/DLL** – select the executable you want to test.
+2. **Flow YAML** – open an existing flow to view or branch.
+
+### Recording
+
+- Choose an application JAR/DLL and click **Start Recording**.
+- Interact with your application. When done, click **Stop**.
+
+### Branching
+
+- Load a flow YAML file.
+- Right-click any step and select **Create Branch** to generate a new YAML file starting at that step.
+
+The UI uses the same plugins as the CLI and stores output in the directory where it is run.


### PR DESCRIPTION
Closes #123

## Summary
- document installation instructions
- document CLI commands and UI walkthrough
- provide contribution overview
- link new docs from README

## Testing
- `gradle build`
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_6862301a082c832a93a4e2b0f26a53be