### PR TITLE
feat: add flow validation

### DIFF
--- a/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import tech.softwareologists.qa.core.Flow
 import tech.softwareologists.qa.core.FlowIO
+import tech.softwareologists.qa.core.FlowValidator
 import tech.softwareologists.qa.app.BranchCreateCommand
 import javax.swing.JFileChooser
 
@@ -47,7 +48,9 @@ fun MainScreen() {
         val chooser = JFileChooser()
         if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
             flowPath = chooser.selectedFile.absolutePath
-            flow = FlowIO.read(java.nio.file.Path.of(flowPath))
+            val loaded = FlowIO.read(java.nio.file.Path.of(flowPath))
+            FlowValidator.validate(loaded)
+            flow = loaded
         }
     }
 

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/Main.kt
@@ -11,6 +11,7 @@ import tech.softwareologists.qa.core.FlowIO
 import tech.softwareologists.qa.core.FlowStep
 import tech.softwareologists.qa.core.LaunchConfig
 import tech.softwareologists.qa.core.PluginRegistry
+import tech.softwareologists.qa.core.FlowValidator
 
 class RecordCommand : CliktCommand(help = "Record application interactions") {
     private val executable by argument(help = "Path to application JAR/DLL").path()
@@ -48,6 +49,7 @@ class BranchCreateCommand : CliktCommand(name = "create", help = "Create a new b
 
     override fun run() {
         val flow = FlowIO.read(base)
+        FlowValidator.validate(flow)
         val index = flow.steps.indexOfFirst { it.id == at }
         if (index < 0) {
             echo("Step '$at' not found in ${'$'}base")

--- a/app/src/test/kotlin/tech/softwareologists/qa/app/BranchCommandTest.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/BranchCommandTest.kt
@@ -2,6 +2,7 @@ import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 import tech.softwareologists.qa.core.*
 import tech.softwareologists.qa.app.BranchCreateCommand
 
@@ -33,6 +34,21 @@ class BranchCommandTest {
         assertTrue(java.nio.file.Files.exists(variantFile))
         val branched = FlowIO.read(variantFile)
         assertEquals(steps.subList(0, 2), branched.steps)
+
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun branch_command_rejects_invalid_flow() {
+        val dir = createTempDirectory()
+        val base = dir.resolve("flow.yaml")
+        java.nio.file.Files.writeString(base, "version: '1'")
+
+        assertFailsWith<Exception> {
+            BranchCreateCommand().parse(
+                arrayOf("--base", base.toString(), "--at", "1", "--name", "x")
+            )
+        }
 
         dir.toFile().deleteRecursively()
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.dataformat.yaml)
     implementation(libs.jackson.datatype.jsr310)
+    implementation(libs.json.schema.validator)
     testImplementation(kotlin("test"))
 }
 

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowIO.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowIO.kt
@@ -2,6 +2,7 @@ package tech.softwareologists.qa.core
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.nio.file.Files
 import java.nio.file.Path
@@ -9,9 +10,11 @@ import java.nio.file.Path
 /** Utility for reading and writing [Flow] objects as YAML. */
 object FlowIO {
     private val mapper: ObjectMapper =
-        ObjectMapper(YAMLFactory())
-            .registerKotlinModule()
-            .findAndRegisterModules()
+        ObjectMapper(YAMLFactory()).apply {
+            registerKotlinModule()
+            registerModule(JavaTimeModule())
+            disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        }
 
     fun write(flow: Flow, path: Path) {
         Files.newBufferedWriter(path).use { writer ->
@@ -21,6 +24,8 @@ object FlowIO {
 
     fun read(path: Path): Flow =
         Files.newBufferedReader(path).use { reader ->
-            mapper.readValue(reader, Flow::class.java)
+            val flow = mapper.readValue(reader, Flow::class.java)
+            FlowValidator.validate(flow)
+            flow
         }
 }

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowValidator.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowValidator.kt
@@ -1,0 +1,36 @@
+package tech.softwareologists.qa.core
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+
+/** Validates [Flow] objects against the bundled JSON schema. */
+object FlowValidator {
+    private val jsonMapper: ObjectMapper =
+        ObjectMapper().apply {
+            registerKotlinModule()
+            findAndRegisterModules()
+            disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        }
+    private val schema = run {
+        val mapper = ObjectMapper(YAMLFactory()).registerKotlinModule().findAndRegisterModules()
+        val stream = requireNotNull(FlowValidator::class.java.getResourceAsStream("/flow.schema.yaml")) {
+            "flow.schema.yaml not found"
+        }
+        val schemaNode: JsonNode = mapper.readTree(stream)
+        JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7).getSchema(schemaNode)
+    }
+
+    /** Throws [IllegalArgumentException] if the given [flow] violates the schema. */
+    fun validate(flow: Flow) {
+        val node = jsonMapper.valueToTree<JsonNode>(flow)
+        val errors = schema.validate(node)
+        if (errors.isNotEmpty()) {
+            val message = errors.joinToString("; ") { it.message }
+            throw IllegalArgumentException("Invalid flow: $message")
+        }
+    }
+}

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/FlowIOTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/FlowIOTest.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class FlowIOTest {
     @Test
@@ -31,5 +32,17 @@ class FlowIOTest {
 
         Files.deleteIfExists(file)
         Files.deleteIfExists(tempDir)
+    }
+
+    @Test
+    fun invalid_flow_is_rejected() {
+        val dir = createTempDirectory()
+        val file = dir.resolve("bad.yaml")
+        Files.writeString(file, "version: '1'")
+
+        assertFailsWith<Exception> { FlowIO.read(file) }
+
+        Files.deleteIfExists(file)
+        Files.deleteIfExists(dir)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,3 +29,4 @@ compose-ui-test-junit4 = { group = "org.jetbrains.compose.ui", name = "ui-test-j
 jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
 jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
+json-schema-validator = { group = "com.networknt", name = "json-schema-validator", version = "1.5.6" }


### PR DESCRIPTION
Closes #0

## Summary
- load `flow.schema.yaml` and validate flows with a new `FlowValidator`
- invoke validator in `FlowIO` and CLI commands
- reject invalid flows in tests

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_b_6862d9f820a0832a85b6eca8ef1e2e3d