### PR TITLE
feat: stop recording cleanup

### DIFF
--- a/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/ComposeMain.kt
@@ -21,7 +21,7 @@ import tech.softwareologists.qa.app.BranchCreateCommand
 import javax.swing.JFileChooser
 
 @Composable
-fun MainScreen() {
+fun MainScreen(recorder: FlowRecorder = PluginFlowRecorder()) {
     var jarPath by remember { mutableStateOf("") }
     var isRecording by remember { mutableStateOf(false) }
     var flowPath by remember { mutableStateOf("") }
@@ -35,12 +35,22 @@ fun MainScreen() {
     }
 
     fun startRecording() {
-        RecordCommand().main(arrayOf(jarPath))
+        recorder.start(jarPath)
         isRecording = true
     }
 
     fun stopRecording() {
-        // Placeholder for stop logic
+        val target = if (flowPath.isNotBlank()) {
+            java.nio.file.Path.of(flowPath)
+        } else {
+            java.nio.file.Path.of("flow.yaml")
+        }
+        recorder.stop(target)
+        if (java.nio.file.Files.exists(target)) {
+            val loaded = FlowIO.read(target)
+            FlowValidator.validate(loaded)
+            flow = loaded
+        }
         isRecording = false
     }
 

--- a/app/src/main/kotlin/tech/softwareologists/qa/app/FlowRecorder.kt
+++ b/app/src/main/kotlin/tech/softwareologists/qa/app/FlowRecorder.kt
@@ -1,0 +1,61 @@
+package tech.softwareologists.qa.app
+
+import tech.softwareologists.qa.core.*
+import java.nio.file.Path
+
+/**
+ * Handles start and stop of recording sessions for the Compose UI.
+ */
+interface FlowRecorder {
+    fun start(jarPath: String)
+    fun stop(output: Path)
+}
+
+/** Default [FlowRecorder] used by the application. */
+class PluginFlowRecorder : FlowRecorder {
+    private var http: HttpEmulator? = null
+    private var fileIo: FileIoEmulator? = null
+    private var process: Process? = null
+
+    override fun start(jarPath: String) {
+        val exe = Path.of(jarPath)
+        val httpEmulator = PluginRegistry.httpEmulators.firstOrNull()
+        val fileEmulator = PluginRegistry.fileIoEmulators.firstOrNull()
+        val launcher = PluginRegistry.launcherPlugins.firstOrNull()
+
+        if (httpEmulator == null || fileEmulator == null || launcher == null) {
+            return
+        }
+
+        http = httpEmulator
+        fileIo = fileEmulator
+
+        httpEmulator.start()
+        fileEmulator.watch(listOf(exe.parent))
+        process = launcher.launch(LaunchConfig(exe))
+    }
+
+    override fun stop(output: Path) {
+        process?.destroy()
+        process?.waitFor()
+        val httpEmulator = http
+        val fileEmulator = fileIo
+        httpEmulator?.stop()
+        fileEmulator?.stop()
+
+        val flow = Flow(
+            version = "1",
+            appVersion = "unknown",
+            emulator = EmulatorData(
+                http = HttpData(httpEmulator?.interactions() ?: emptyList()),
+                file = FileData(fileEmulator?.events() ?: emptyList())
+            ),
+            steps = emptyList()
+        )
+        FlowIO.write(flow, output)
+
+        process = null
+        http = null
+        fileIo = null
+    }
+}

--- a/app/src/test/kotlin/tech/softwareologists/qa/app/MainScreenTest.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/MainScreenTest.kt
@@ -3,15 +3,25 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.*
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
+import tech.softwareologists.qa.app.FlowRecorder
 
 class MainScreenTest {
     @get:Rule
     val composeTestRule: ComposeContentTestRule = createComposeRule()
 
+    private class FakeRecorder : FlowRecorder {
+        var startCalled = 0
+        var stopCalled = 0
+        override fun start(jarPath: String) { startCalled++ }
+        override fun stop(output: java.nio.file.Path) { stopCalled++ }
+    }
+
     @Test
     fun start_and_stop_button_toggle_state() {
+        val recorder = FakeRecorder()
         composeTestRule.setContent {
-            tech.softwareologists.qa.app.MainScreen()
+            tech.softwareologists.qa.app.MainScreen(recorder)
         }
 
         val startButton = composeTestRule.onNodeWithText("Start Recording")
@@ -27,7 +37,46 @@ class MainScreenTest {
 
         stopButton.performClick()
 
+        assertEquals(1, recorder.startCalled)
+        assertEquals(1, recorder.stopCalled)
+
         startButton.assertIsEnabled()
         stopButton.assertIsNotEnabled()
+    }
+
+    @Test
+    fun stop_writes_flow_file() {
+        val dir = kotlin.io.path.createTempDirectory()
+        val output = dir.resolve("flow.yaml")
+        val recorder = object : FlowRecorder {
+            override fun start(jarPath: String) {}
+            override fun stop(output: java.nio.file.Path) {
+                val flow = tech.softwareologists.qa.core.Flow(
+                    version = "1",
+                    appVersion = "test",
+                    emulator = tech.softwareologists.qa.core.EmulatorData(
+                        tech.softwareologists.qa.core.HttpData(),
+                        tech.softwareologists.qa.core.FileData()
+                    ),
+                    steps = emptyList()
+                )
+                tech.softwareologists.qa.core.FlowIO.write(flow, output)
+            }
+        }
+
+        composeTestRule.setContent {
+            tech.softwareologists.qa.app.MainScreen(recorder)
+        }
+
+        // enter flow path
+        composeTestRule.onNodeWithText("Flow YAML")
+            .performTextInput(output.toString())
+
+        composeTestRule.onNodeWithText("Start Recording").performClick()
+        composeTestRule.onNodeWithText("Stop").performClick()
+
+        kotlin.test.assertTrue(java.nio.file.Files.exists(output))
+
+        dir.toFile().deleteRecursively()
     }
 }


### PR DESCRIPTION
Closes #13

## Summary
- implement `PluginFlowRecorder` used by Compose UI
- call recorder stop logic to shutdown emulators and write flow file
- allow injection of recorder for tests
- verify start/stop buttons trigger recorder actions and flow file creation

## Testing
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_6862dde1afb8832a801ce10daf80e29f