### PR TITLE
feat: implement CLI replay/run commands

### DIFF
--- a/app/src/test/kotlin/tech/softwareologists/qa/app/ReplayRunCommandTest.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/ReplayRunCommandTest.kt
@@ -1,0 +1,53 @@
+package tech.softwareologists.qa.app
+
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import tech.softwareologists.qa.core.*
+import java.nio.file.Files
+import java.time.Instant
+
+class ReplayRunCommandTest {
+    private fun createFlow(dir: java.nio.file.Path): java.nio.file.Path {
+        val flow = Flow(
+            version = "1",
+            appVersion = "test",
+            emulator = EmulatorData(
+                HttpData(listOf(HttpInteraction("GET", "/hello"))),
+                FileData(listOf(FileEvent(FileEventType.CREATE, dir.resolve("a.txt"), Instant.EPOCH)))
+            ),
+            steps = emptyList()
+        )
+        val file = dir.resolve("flow.yaml")
+        FlowIO.write(flow, file)
+        return file
+    }
+
+    @Test
+    fun replay_command_executes_flow() {
+        val dir = createTempDirectory()
+        val flowFile = createFlow(dir)
+        ReplayCommand().parse(arrayOf("--flow", flowFile.toString()))
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun run_command_collects_evidence() {
+        val dir = createTempDirectory()
+        val reports = createTempDirectory()
+        val flowFile = createFlow(dir)
+
+        RunCommand().parse(arrayOf("--flow", flowFile.toString(), "--reportDir", reports.toString()))
+
+        val flowName = flowFile.fileName.toString().substringBeforeLast('.')
+        val tsDir = Files.list(reports.resolve(flowName)).findFirst().get()
+        assertTrue(Files.exists(tsDir.resolve("http_interactions.json")))
+        assertTrue(Files.exists(tsDir.resolve("file_events.json")))
+        assertTrue(Files.exists(tsDir.resolve("db_dump.sql")))
+        assertTrue(Files.exists(tsDir.resolve("junit.xml")))
+        assertTrue(Files.exists(tsDir.resolve("summary.html")))
+
+        dir.toFile().deleteRecursively()
+        reports.toFile().deleteRecursively()
+    }
+}

--- a/app/src/test/kotlin/tech/softwareologists/qa/app/TestPlugins.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/TestPlugins.kt
@@ -1,0 +1,46 @@
+package tech.softwareologists.qa.app
+
+import tech.softwareologists.qa.core.*
+import java.nio.file.Path
+import java.time.Instant
+import java.nio.file.Files
+
+class TestHttpEmulator : HttpEmulator {
+    private val recorded = mutableListOf<HttpInteraction>()
+    override fun start(): String {
+        instance = this
+        return "http://localhost"
+    }
+    override fun stop() {}
+    override fun interactions(): List<HttpInteraction> = recorded.toList()
+    fun record(method: String = "GET", path: String = "/hello") {
+        recorded += HttpInteraction(method, path)
+    }
+    companion object {
+        var instance: TestHttpEmulator? = null
+    }
+}
+
+class TestFileIoEmulator : FileIoEmulator {
+    override fun watch(paths: List<Path>) {}
+    override fun stop() {}
+    override fun events(): List<FileEvent> = listOf(
+        FileEvent(FileEventType.CREATE, Path.of("a.txt"), Instant.EPOCH)
+    )
+}
+
+class TestLauncher : LauncherPlugin {
+    override fun supports(config: LaunchConfig): Boolean = true
+    override fun launch(config: LaunchConfig): Process {
+        TestHttpEmulator.instance?.record()
+        return ProcessBuilder("true").start()
+    }
+}
+
+class TestDatabaseManager : DatabaseManager {
+    override fun startDatabase(): DatabaseInfo = DatabaseInfo("", "", "")
+    override fun exportDump(target: Path) {
+        Files.writeString(target, "dump")
+    }
+    override fun stop() {}
+}

--- a/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.DatabaseManager
+++ b/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.DatabaseManager
@@ -1,0 +1,1 @@
+tech.softwareologists.qa.app.TestDatabaseManager

--- a/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.FileIoEmulator
+++ b/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.FileIoEmulator
@@ -1,0 +1,1 @@
+tech.softwareologists.qa.app.TestFileIoEmulator

--- a/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.HttpEmulator
+++ b/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.HttpEmulator
@@ -1,0 +1,1 @@
+tech.softwareologists.qa.app.TestHttpEmulator

--- a/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.LauncherPlugin
+++ b/app/src/test/resources/META-INF/services/tech.softwareologists.qa.core.LauncherPlugin
@@ -1,0 +1,1 @@
+tech.softwareologists.qa.app.TestLauncher


### PR DESCRIPTION
Closes #??? (no issue specified)

## Summary
- implement `ReplayCommand` to load a flow and invoke `FlowExecutor.playback`
- implement `RunCommand` to execute a flow and collect evidence
- provide service-loader based test plugins
- add tests verifying replay and evidence generation

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_b_6862e2204cd0832a960f7fc646785aa1