### PR TITLE
feat: add webhook integration

### DIFF
--- a/agent/src/main/kotlin/tech/softwareologists/qa/agent/AgentConfig.kt
+++ b/agent/src/main/kotlin/tech/softwareologists/qa/agent/AgentConfig.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
 import tech.softwareologists.qa.core.FlowExecutor
 import tech.softwareologists.qa.fileio.NioFileIoEmulator
 import tech.softwareologists.qa.http.KtorHttpEmulator
@@ -29,4 +30,7 @@ class AgentConfig {
     @Bean
     fun yamlMapper(): ObjectMapper =
         ObjectMapper(YAMLFactory()).registerKotlinModule().findAndRegisterModules()
+
+    @Bean
+    fun webClient(builder: WebClient.Builder): WebClient = builder.build()
 }

--- a/agent/src/main/kotlin/tech/softwareologists/qa/agent/RunService.kt
+++ b/agent/src/main/kotlin/tech/softwareologists/qa/agent/RunService.kt
@@ -1,8 +1,12 @@
 package tech.softwareologists.qa.agent
 
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
 import tech.softwareologists.qa.core.FlowExecutor
 import tech.softwareologists.qa.core.LaunchConfig
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -12,7 +16,9 @@ data class RunResult(val id: String, val success: Boolean, val details: List<Str
 @Service
 class RunService(
     private val repository: FlowRepository,
-    private val executor: FlowExecutor
+    private val executor: FlowExecutor,
+    private val webClient: WebClient,
+    @Value("\${qa.webhook-url:}") private val webhookUrl: String?
 ) {
     private val results = ConcurrentHashMap<String, RunResult>()
 
@@ -20,14 +26,33 @@ class RunService(
         val flow = repository.get(flowId) ?: throw IllegalArgumentException("Flow not found: $flowId")
         val runId = UUID.randomUUID().toString()
         val workingDir = java.nio.file.Files.createTempDirectory("run")
+        val reportDir = Files.createTempDirectory("report")
         val result = try {
             executor.playback(flow, LaunchConfig(Path.of("/usr/bin/true"), workingDir = workingDir))
             RunResult(runId, true)
         } catch (e: Exception) {
             RunResult(runId, false, listOfNotNull(e.message))
-        } finally {
-            workingDir.toFile().deleteRecursively()
         }
+        executor.collectEvidence(flowId, reportDir, result.success, result.details)
+        workingDir.toFile().deleteRecursively()
+
+        if (!webhookUrl.isNullOrBlank()) {
+            try {
+                val tsDir = Files.list(reportDir.resolve(flowId)).findFirst().get()
+                val payload = Files.readString(tsDir.resolve("result.json"))
+                webClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(payload)
+                    .retrieve()
+                    .bodyToMono(Void::class.java)
+                    .block()
+            } catch (ex: Exception) {
+                println("Webhook POST failed: ${ex.message}")
+            }
+        }
+        reportDir.toFile().deleteRecursively()
+
         results[runId] = result
         return result
     }

--- a/agent/src/test/kotlin/tech/softwareologists/qa/agent/RunWebhookTest.kt
+++ b/agent/src/test/kotlin/tech/softwareologists/qa/agent/RunWebhookTest.kt
@@ -1,0 +1,77 @@
+package tech.softwareologists.qa.agent
+
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RunWebhookTest {
+    @Autowired
+    lateinit var client: WebTestClient
+
+    companion object {
+        private val received = CompletableFuture<String>()
+        private val server: HttpServer = HttpServer.create(InetSocketAddress(0), 0).apply {
+            createContext("/hook") { exchange ->
+                val body = String(exchange.requestBody.readAllBytes(), StandardCharsets.UTF_8)
+                received.complete(body)
+                exchange.sendResponseHeaders(200, 0)
+                exchange.responseBody.close()
+            }
+            start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("qa.webhook-url") { "http://localhost:${server.address.port}/hook" }
+        }
+    }
+
+    @AfterAll
+    fun tearDown() {
+        server.stop(0)
+    }
+
+    private val sampleFlow = """
+        version: "1"
+        appVersion: "test"
+        emulator:
+          http:
+            interactions: []
+          file:
+            events: []
+        steps: []
+    """.trimIndent()
+
+    @Test
+    fun posts_result_json() {
+        val flowId = client.post().uri("/flows")
+            .bodyValue(sampleFlow)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(FlowInfo::class.java)
+            .returnResult().responseBody!!.id
+
+        client.post().uri("/flows/{id}/run", flowId)
+            .exchange()
+            .expectStatus().isOk
+
+        val body = received.get(5, TimeUnit.SECONDS)
+        assertTrue(body.contains("\"success\":true"))
+    }
+}


### PR DESCRIPTION
Closes #18

## Summary
- add `webClient` bean
- extend `RunService` to send `result.json` to optional webhook
- create `RunWebhookTest` covering payload delivery

## Testing
- `gradle :core:test :agent:test --no-daemon`
- `gradle lint --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_6862ec239248832a86810acf1c6f9202