### PR TITLE
ci: publish binaries on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.7'
+      - name: Build
+        run: gradle build
+      - name: Run tests
+        run: gradle test
+      - name: Lint
+        run: gradle ktlintCheck
+      - name: Build Distributions
+        run: gradle :app:distZip :agent:bootJar
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            app/build/distributions/*.zip
+            agent/build/libs/*.jar
+

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,23 @@
+# Release Process
+
+This project publishes a GitHub release whenever a new git tag is pushed.
+Tags should follow semantic versioning, e.g. `v1.2.3`.
+If the tag contains a suffix such as `-rc1` it will be marked as a pre-release.
+
+## Steps
+
+1. Update `CHANGELOG.md` with the new version entry.
+2. Commit your changes and create an annotated tag:
+   
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+   
+   Replace `vX.Y.Z` with your version. Add a suffix like `-beta1` for pre-releases.
+3. Pushing the tag triggers the `release.yml` workflow which:
+   - Builds all modules and runs tests and lint checks.
+   - Creates application and agent binaries.
+   - Uploads the artifacts as release assets.
+4. Verify the GitHub release page for the uploaded binaries.
+


### PR DESCRIPTION
## Summary
- create release workflow to build binaries on tag push
- document release steps in `docs/RELEASE.md`

## Testing
- `gradle build`
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_6862f29bedb0832aa560d3360d07fffe