### PR TITLE
feat: add conditional flow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **Purpose-Built Sandbox**: Lightweight HTTP and file I/O emulators—no Docker or VM required.
 - **Extensible Plugin SPI**: Easily add new launchers, emulators, or database providers.
 - **Flow Definitions**: YAML-based flows with JSON-Schema validation for accuracy.
+- **Conditional Logic**: Execute steps conditionally and loop over actions for complex workflows.
 - **Branch Management**: Create variants at any step to test alternate scenarios.
 - **Evidence Collection**: Generate HTTP HARs, file event logs, database dumps, JUnit-XML, and HTML reports.
 - **CI/CD Ready**: Automated builds, sample flow runs, and report publishing via GitHub Actions.
@@ -31,6 +32,11 @@ See [docs/UI_WALKTHROUGH.md](docs/UI_WALKTHROUGH.md) for a walkthrough of the de
 ### CLI Quickstart
 
 See [docs/CLI_USAGE.md](docs/CLI_USAGE.md) for detailed command examples.
+
+### Conditional Steps
+
+Flows can include `if`/`then`/`else` blocks and `loop` directives. The
+`FlowExecutor` evaluates these at runtime to support polling and cleanup logic.
 ## Examples
 
 Sample workflows and reports are available under the `examples/` directory:

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/Flow.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/Flow.kt
@@ -28,7 +28,26 @@ data class FileData(
 )
 
 /** User-defined step within a flow. */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
 data class FlowStep(
     val id: String,
-    val description: String
+    val description: String,
+    @com.fasterxml.jackson.annotation.JsonProperty("if")
+    val condition: Condition? = null,
+    val then: List<FlowStep>? = null,
+    @com.fasterxml.jackson.annotation.JsonProperty("else")
+    val elseSteps: List<FlowStep>? = null,
+    val loop: Loop? = null,
+)
+
+data class Condition(
+    val stepId: String,
+    val path: String,
+    val equals: String,
+)
+
+data class Loop(
+    val steps: List<FlowStep>,
+    val until: Condition? = null,
+    val count: Int? = null,
 )

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/FlowExecutor.kt
@@ -40,7 +40,12 @@ class FlowExecutor(
      * interactions are compared against those recorded in the flow. A mismatch
      * will throw an [IllegalStateException].
      */
-    fun playback(flow: Flow, config: LaunchConfig, variables: Map<String, String> = emptyMap()) {
+    fun playback(
+        flow: Flow,
+        config: LaunchConfig,
+        variables: Map<String, String> = emptyMap(),
+        stepAction: (FlowStep) -> Map<String, Any?> = { emptyMap() },
+    ) {
         val resolvedFlow = flow.applyVariables(variables)
         val resolvedConfig = config.applyVariables(resolvedFlow.variables + variables)
 
@@ -68,6 +73,8 @@ class FlowExecutor(
                 "HTTP interactions mismatch. Expected $expected, got $actual"
             )
         }
+
+        StepExecutor(stepAction).run(resolvedFlow.steps)
     }
 
     /**

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/StepExecutor.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/StepExecutor.kt
@@ -1,0 +1,42 @@
+package tech.softwareologists.qa.core
+
+/** Simple executor that handles conditional and looped steps. */
+class StepExecutor(private val action: (FlowStep) -> Map<String, Any?> = { emptyMap<String, Any?>() }) {
+    val results: MutableMap<String, Map<String, Any?>> = mutableMapOf()
+
+    fun run(steps: List<FlowStep>) {
+        steps.forEach { execute(it) }
+    }
+
+    private fun execute(step: FlowStep) {
+        step.loop?.let { runLoop(step.id, it); return }
+
+        val conditionMet = step.condition?.let { evaluate(it) } ?: true
+        val branch = if (conditionMet) step.then ?: emptyList() else step.elseSteps ?: emptyList()
+        if (branch.isNotEmpty()) {
+            branch.forEach { execute(it) }
+            results[step.id] = mapOf("executed" to true)
+        } else {
+            val result = action(step)
+            results[step.id] = result
+        }
+    }
+
+    private fun runLoop(id: String, loop: Loop) {
+        var iterations = 0
+        while (true) {
+            loop.steps.forEach { execute(it) }
+            iterations++
+            val untilOk = loop.until?.let { evaluate(it) } ?: false
+            if ((loop.count != null && iterations >= loop.count) || untilOk) break
+        }
+        results[id] = mapOf("iterations" to iterations)
+    }
+
+    private fun evaluate(cond: Condition): Boolean {
+        val result = results[cond.stepId] ?: return false
+        val path = cond.path.removePrefix("$.")
+        val value = (result[path] ?: return false).toString()
+        return value == cond.equals
+    }
+}

--- a/core/src/main/resources/flow.schema.yaml
+++ b/core/src/main/resources/flow.schema.yaml
@@ -71,13 +71,55 @@ properties:
       - http
       - file
   steps:
+    $ref: '#/definitions/stepList'
+
+definitions:
+  condition:
+    type: object
+    description: Condition evaluated against a previous step's result.
+    required: [stepId, path, equals]
+    properties:
+      stepId:
+        type: string
+        description: Identifier of the step to inspect.
+      path:
+        type: string
+        description: JSON path expression for the value to compare.
+      equals:
+        type: string
+        description: Expected value for the condition to be true.
+
+  loop:
+    type: object
+    description: Repeats a list of steps until a condition or count is met.
+    required: [steps]
+    properties:
+      steps:
+        $ref: '#/definitions/stepList'
+      until:
+        $ref: '#/definitions/condition'
+      count:
+        type: integer
+        minimum: 1
+
+  step:
+    type: object
+    required: [id, description]
+    properties:
+      id:
+        type: string
+      description:
+        type: string
+      if:
+        $ref: '#/definitions/condition'
+      then:
+        $ref: '#/definitions/stepList'
+      else:
+        $ref: '#/definitions/stepList'
+      loop:
+        $ref: '#/definitions/loop'
+
+  stepList:
     type: array
-    description: Ordered steps performed during the flow.
     items:
-      type: object
-      required: [id, description]
-      properties:
-        id:
-          type: string
-        description:
-          type: string
+      $ref: '#/definitions/step'

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/StepExecutorTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/StepExecutorTest.kt
@@ -1,0 +1,59 @@
+package tech.softwareologists.qa.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class StepExecutorTest {
+    @Test
+    fun loop_until_condition_met() {
+        val loopStep = FlowStep(
+            id = "poll",
+            description = "Poll for status",
+            loop = Loop(
+                steps = listOf(FlowStep("check", "Check status")),
+                until = Condition("check", "$.status", "READY"),
+            )
+        )
+        var attempt = 0
+        val executor = StepExecutor { step ->
+            if (step.id == "check") {
+                attempt++
+                mapOf("status" to if (attempt < 3) "WAIT" else "READY")
+            } else emptyMap()
+        }
+        executor.run(listOf(loopStep))
+        assertEquals(3, attempt)
+        assertEquals("READY", executor.results["check"]?.get("status"))
+        assertEquals(3, executor.results["poll"]?.get("iterations"))
+    }
+
+    @Test
+    fun executes_then_or_else_branch() {
+        val steps = listOf(
+            FlowStep("setup", "Set flag"),
+            FlowStep(
+                id = "cond",
+                description = "Branch",
+                condition = Condition("setup", "$.ready", "yes"),
+                then = listOf(FlowStep("then", "then")),
+                elseSteps = listOf(FlowStep("else", "else")),
+            )
+        )
+        var first = true
+        val executor = StepExecutor { step ->
+            if (step.id == "setup") {
+                val value = if (first) "no" else "yes"
+                first = false
+                mapOf("ready" to value)
+            } else emptyMap()
+        }
+        executor.run(steps)
+        assertNotNull(executor.results["else"])
+        // second run to trigger then branch
+        executor.results.clear()
+        first = false
+        executor.run(steps)
+        assertNotNull(executor.results["then"])
+    }
+}

--- a/examples/sample-workflow.yaml
+++ b/examples/sample-workflow.yaml
@@ -30,3 +30,22 @@ steps:
     description: Issue API requests
   - id: "3"
     description: Write output file
+  - id: "4"
+    description: Poll for status
+    loop:
+      steps:
+        - id: "4.1"
+          description: Check status endpoint
+      until:
+        stepId: "4.1"
+        path: $.status
+        equals: READY
+  - id: "5"
+    description: Conditional cleanup
+    if:
+      stepId: "4.1"
+      path: $.status
+      equals: FAILED
+    then:
+      - id: "5.1"
+        description: Capture logs


### PR DESCRIPTION
Closes #1

## Summary
- implement `Condition`, `Loop`, and extended `FlowStep` with optional nested steps
- create `StepExecutor` and integrate into `FlowExecutor`
- cover conditional and looped execution with unit tests
- document conditional steps in README

## Testing
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_6862f54b1238832aa51e0244e32a0acf