### PR TITLE
feat: add database seeding and cleanup SPI

### DIFF
--- a/app/src/test/kotlin/tech/softwareologists/qa/app/TestPlugins.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/TestPlugins.kt
@@ -39,8 +39,10 @@ class TestLauncher : LauncherPlugin {
 
 class TestDatabaseManager : DatabaseManager {
     override fun startDatabase(): DatabaseInfo = DatabaseInfo("", "", "")
+    override fun seed(dataset: Path) {}
     override fun exportDump(target: Path) {
         Files.writeString(target, "dump")
     }
+    override fun cleanup() {}
     override fun stop() {}
 }

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/SandboxSPI.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/SandboxSPI.kt
@@ -86,8 +86,14 @@ interface DatabaseManager {
     /** Starts the database and returns connection information. */
     fun startDatabase(): DatabaseInfo
 
+    /** Seeds the database using the SQL script at [dataset]. */
+    fun seed(dataset: Path)
+
     /** Exports a dump of the current database state to the given path. */
     fun exportDump(target: Path)
+
+    /** Cleans up any seeded data, returning the database to an empty state. */
+    fun cleanup()
 
     /** Stops the database and cleans up resources. */
     fun stop()

--- a/core/src/test/kotlin/tech/softwareologists/qa/core/EvidenceCollectionTest.kt
+++ b/core/src/test/kotlin/tech/softwareologists/qa/core/EvidenceCollectionTest.kt
@@ -32,9 +32,11 @@ private class DummyLauncher(private val http: RecordingHttpEmulator) : LauncherP
 
 private class DumpingDatabaseManager : DatabaseManager {
     override fun startDatabase(): DatabaseInfo = DatabaseInfo("", "", "")
+    override fun seed(dataset: java.nio.file.Path) {}
     override fun exportDump(target: java.nio.file.Path) {
         Files.writeString(target, "dump")
     }
+    override fun cleanup() {}
     override fun stop() {}
 }
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -33,7 +33,7 @@ All extensible behaviours are defined in the `core` module under
 - `HttpEmulator` – records and replays HTTP calls.
 - `FileIoEmulator` – monitors file system events.
 - `LauncherPlugin` – launches the system under test.
-- `DatabaseManager` – provisions and exports sandbox databases.
+- `DatabaseManager` – provisions sandbox databases, seeds test data, exports dumps, and cleans up.
 
 A new plugin implements one of these interfaces and registers itself via the
 Java `ServiceLoader`. Each plugin module provides a service descriptor under

--- a/plugins/database-manager-h2/src/test/kotlin/tech/softwareologists/qa/database/H2DatabaseManagerTest.kt
+++ b/plugins/database-manager-h2/src/test/kotlin/tech/softwareologists/qa/database/H2DatabaseManagerTest.kt
@@ -23,4 +23,28 @@ class H2DatabaseManagerTest {
         assertTrue(text.contains("'hello'"))
         manager.stop()
     }
+
+    @Test
+    fun `seeds and cleans up database`() {
+        val manager = H2DatabaseManager()
+        val info = manager.startDatabase()
+        val dataset = Files.createTempFile("seed", ".sql")
+        Files.writeString(dataset, "CREATE TABLE sample(id INT);INSERT INTO sample VALUES(1)")
+        manager.seed(dataset)
+        DriverManager.getConnection(info.jdbcUrl, info.username, info.password).use { conn ->
+            conn.createStatement().use { st ->
+                val rs = st.executeQuery("SELECT COUNT(*) FROM sample")
+                rs.next()
+                assertTrue(rs.getInt(1) == 1)
+            }
+        }
+        manager.cleanup()
+        DriverManager.getConnection(info.jdbcUrl, info.username, info.password).use { conn ->
+            val meta = conn.metaData
+            meta.getTables(null, null, "SAMPLE", null).use { rs ->
+                assertTrue(!rs.next())
+            }
+        }
+        manager.stop()
+    }
 }


### PR DESCRIPTION
Closes #10

## Summary
- extend `DatabaseManager` SPI with `seed` and `cleanup` methods
- implement the new methods in H2, JDBC, and SQL Server managers
- update tests to cover seeding and cleanup behavior
- adjust internal test utilities for new interface
- document enhanced `DatabaseManager` responsibilities

## Testing
- `gradle ktlintCheck`
- `gradle test`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_b_6862ff617580832ab4b309796b7ae8df