### PR TITLE
ci: generate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
           files: |
             app/build/distributions/*.zip
             agent/build/libs/*.jar

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -18,6 +18,6 @@ If the tag contains a suffix such as `-rc1` it will be marked as a pre-release.
 3. Pushing the tag triggers the `release.yml` workflow which:
    - Builds all modules and runs tests and lint checks.
    - Creates application and agent binaries.
-   - Uploads the artifacts as release assets.
+   - Generates release notes and uploads the artifacts as release assets.
 4. Verify the GitHub release page for the uploaded binaries.
 


### PR DESCRIPTION
## Summary
- generate release notes automatically when publishing a release

## Testing
- `gradle build`
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_686307c8a5b4832aa0379e7fd2f06784