### PR TITLE
fix: end-to-end runner stability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 
 dependencies {
     implementation(project(":core"))
+    implementation(project(":plugins:http-emulator"))
+    implementation(project(":plugins:fileio-emulator"))
+    implementation(project(":plugins:jar-launcher"))
     implementation(libs.clikt)
     implementation(compose.desktop.currentOs)
     implementation(compose.material3)

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/Flow.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/Flow.kt
@@ -54,6 +54,9 @@ data class Condition(
     val equals: String,
 )
 
+@com.fasterxml.jackson.annotation.JsonInclude(
+    com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
+)
 data class Loop(
     val steps: List<FlowStep>,
     val until: Condition? = null,

--- a/core/src/main/kotlin/tech/softwareologists/qa/core/PlaybackUtils.kt
+++ b/core/src/main/kotlin/tech/softwareologists/qa/core/PlaybackUtils.kt
@@ -20,7 +20,9 @@ fun simulateFileEvents(events: List<FileEvent>) {
         when (event.type) {
             FileEventType.CREATE -> {
                 Files.createDirectories(event.path.parent)
-                Files.createFile(event.path)
+                if (Files.notExists(event.path)) {
+                    Files.createFile(event.path)
+                }
             }
 
             FileEventType.DELETE -> Files.deleteIfExists(event.path)


### PR DESCRIPTION
Closes #NA

## Summary
- exclude null count property from Loop to satisfy schema
- include emulator plugins in the app runtime classpath
- skip file creation when file already exists during playback

## Testing
- `gradle test --no-daemon`
- `gradle ktlintCheck --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_686343dec0a4832aa6c6a855ad1c2b1b