### PR TITLE
ci: add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     strategy:


### PR DESCRIPTION
Closes #None

## Summary
- restrict the default token in CI to read-only
- allow release workflow to write contents and pull requests

## Testing
- `gradle build`
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_686356c25ea8832abddc0964b329e2af