### PR TITLE
feat: show run logs in Compose UI

### DIFF
--- a/app/src/test/kotlin/tech/softwareologists/qa/app/MainScreenTest.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/MainScreenTest.kt
@@ -79,4 +79,20 @@ class MainScreenTest {
 
         dir.toFile().deleteRecursively()
     }
+
+    @Test
+    fun run_displays_process_logs() {
+        composeTestRule.setContent {
+            tech.softwareologists.qa.app.MainScreen()
+        }
+
+        composeTestRule.onNodeWithText("Application JAR/DLL")
+            .performTextInput("/tmp/app.jar")
+
+        composeTestRule.onNodeWithText("Run").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            composeTestRule.onAllNodesWithText("test-log").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
 }

--- a/app/src/test/kotlin/tech/softwareologists/qa/app/TestPlugins.kt
+++ b/app/src/test/kotlin/tech/softwareologists/qa/app/TestPlugins.kt
@@ -34,7 +34,7 @@ class TestLauncher : LauncherPlugin {
     override fun supports(config: LaunchConfig): Boolean = true
     override fun launch(config: LaunchConfig): Process {
         TestHttpEmulator.instance?.record()
-        return ProcessBuilder("true").start()
+        return ProcessBuilder("sh", "-c", "echo test-log").start()
     }
 }
 


### PR DESCRIPTION
## Summary
- stream process output during flow playback
- capture logs in Compose UI and display them
- update test launcher to emit a test log line
- test log display in MainScreen

## Testing
- `gradle build -x test`
- `gradle test`
- `gradle ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_b_68636624dfa0832a9d7af215ed767ce6